### PR TITLE
feat: add broadcasting syntax

### DIFF
--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -4,4 +4,5 @@
 GraphPPL.ishead
 GraphPPL.isblock
 GraphPPL.iscall
+GraphPPL.isbroadcastedcall
 ```

--- a/src/backends/reactivemp.jl
+++ b/src/backends/reactivemp.jl
@@ -108,8 +108,16 @@ function write_make_node_expression(::ReactiveMPBackend, model, fform, variables
     return :($nodeexpr = ReactiveMP.make_node($model, $options, $fform, $varexpr, $(variables...)))
 end
 
+function write_broadcasted_make_node_expression(::ReactiveMPBackend, model, fform, variables, options, nodeexpr, varexpr)
+    return :($nodeexpr = ReactiveMP.make_node.($model, $options, $fform, $varexpr, $(variables...)))
+end
+
 function write_autovar_make_node_expression(::ReactiveMPBackend, model, fform, variables, options, nodeexpr, varexpr, autovarid)
     return :(($nodeexpr, $varexpr) = ReactiveMP.make_node($model, $options, $fform, ReactiveMP.AutoVar($(GraphPPL.fquote(autovarid))), $(variables...)))
+end
+
+function write_check_variable_existence(::ReactiveMPBackend, model, varid, errormsg)
+    return :(ReactiveMP.haskey($model, $(QuoteNode(varid))) || Base.error($errormsg))
 end
 
 function write_node_options(::ReactiveMPBackend, model, fform, variables, options)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,6 +33,24 @@ iscall(expr)       = ishead(expr, :call) && length(expr.args) >= 1
 iscall(expr, fsym) = iscall(expr) && first(expr.args) === fsym
 
 """
+    isbroadcastedcall(expr) 
+    isbroadcastedcall(expr, fsym) 
+
+Checks if expression represents a broadcast call to some function. Optionally accepts `fsym` to check for exact function name match.
+
+See also: [`iscall`](@ref)
+"""
+function isbroadcastedcall(expr) 
+    (iscall(expr) && length(expr.args) >= 1 && first(string(first(expr.args))) === '.') || # Checks for `:(a .+ b)` syntax
+        (ishead(expr, :(.))) # Checks for `:(f.(x))` syntax
+end
+
+function isbroadcastedcall(expr, fsym) 
+    (iscall(expr) && length(expr.args) >= 1 && first(string(first(expr.args))) === '.' && Symbol(string(first(expr.args))[2:end]) === fsym) || # Checks for `:(a .+ b)` syntax
+        (ishead(expr, :(.)) && first(expr.args) === fsym) # Checks for `:(f.(x))` syntax
+end
+
+"""
     isref(expr)
 
 Shorthand for `ishead(expr, :ref)`.

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -54,6 +54,28 @@ end
 
 end
 
+@testset "isbroadcastedcall tests" begin 
+    import GraphPPL: isbroadcastedcall
+
+    @test isbroadcastedcall(:(f(1))) === false
+    @test isbroadcastedcall(:(f(1)), :f) === false
+    @test isbroadcastedcall(:(f(1)), :g) === false
+    @test isbroadcastedcall(:(if true 1 else 2 end)) === false
+    @test isbroadcastedcall(:(begin end)) === false
+
+    @test isbroadcastedcall(:(a .+ b)) === true
+    @test isbroadcastedcall(:(a .+ b), :(+)) === true
+    @test isbroadcastedcall(:(a .+ b), :(-)) === false
+
+    @test isbroadcastedcall(:(f.(a))) === true
+    @test isbroadcastedcall(:(f.(a, b))) === true
+    @test isbroadcastedcall(:(f.(a)), :f) === true
+    @test isbroadcastedcall(:(f.(a, b)), :f) === true
+    @test isbroadcastedcall(:(f.(a)), :g) === false
+    @test isbroadcastedcall(:(f.(a, b)), :g) === false
+
+end
+
 @testset "ensure_type tests" begin 
     import GraphPPL: ensure_type
 


### PR DESCRIPTION
This PR adds a broadcasting syntax for tilde operator `.~`