### PR TITLE
feat: priors as arguments support

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -399,9 +399,9 @@ function generate_model_expression(backend, model_specification)
         end
     end
 
-    # Step 4: Main pass
-    # If there are still  unprocessed `~` expressions left we assume these are coming from the input arguments 
-    # We refer to such `~` usage as implicit
+    # Step 4: Auto nodes pass
+    # If there are still unprocessed `~` expressions left we assume these are coming from the input arguments 
+    # We refer to such `~` usage as `auto` nodes
     ms_body = postwalk(ms_body) do expression 
         if @capture(expression, lhs_ ~ rhs_ where { options__ }) || @capture(expression, lhs_ .~ rhs_ where { options__ })
             errmsg = "Implicit `~` usage in the `$expression` expression does not support `where {}` block."


### PR DESCRIPTION
This PR adds a new feature for the `@model` macro and allows passing priors as arguments to the model as:

```julia
@model function coin_model(n, prior)
    y = datavar(Float64, n)
    θ ~ prior
    for i in 1:n
        y[i] ~ Bernoulli(θ)
    end
end
``