### PR TITLE
Redefinition of RV's throws error in more logical places

### DIFF
--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -1,13 +1,6 @@
 using Graphs
 using MetaGraphsNext
-import Base:
-    put!,
-    haskey,
-    gensym,
-    getindex,
-    getproperty,
-    setproperty!,
-    setindex!
+import Base: put!, haskey, gensym, getindex, getproperty, setproperty!, setindex!
 using GraphPlot, Compose
 import Cairo
 
@@ -382,7 +375,8 @@ getifcreated(model::Model, context::Context, var) =
     add_variable_node!(model, context, gensym(model, :constvar); value = var)
 
 get_individual_variable(node::NodeLabel) = node
-get_individual_variable(node::ResizableArray) = error("$node is defined as Array of random variables")
+get_individual_variable(node::ResizableArray) =
+    error("$node is defined as Array of random variables")
 
 """
 Add a variable node to the model with the given ID. This function is unsafe (doesn't check if a variable with the given name already exists in the model). 

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -7,10 +7,7 @@ import Base:
     getindex,
     getproperty,
     setproperty!,
-    setindex!,
-    length,
-    size,
-    resize!
+    setindex!
 using GraphPlot, Compose
 import Cairo
 
@@ -187,6 +184,8 @@ function Base.getindex(c::Context, key::Symbol)
         return c.vector_variables[key]
     elseif haskey(c.tensor_variables, key)
         return c.tensor_variables[key]
+    elseif haskey(c.factor_nodes, key)
+        return c.factor_nodes[key]
     end
     throw(KeyError("Variable " * String(key) * " not found in Context " * c.prefix))
 end
@@ -381,6 +380,9 @@ getifcreated(model::Model, context::Context, var::Union{Tuple,AbstractArray{Node
     map((v) -> getifcreated(model, context, v), var)
 getifcreated(model::Model, context::Context, var) =
     add_variable_node!(model, context, gensym(model, :constvar); value = var)
+
+get_individual_variable(node::NodeLabel) = node
+get_individual_variable(node::ResizableArray) = error("$node is defined as Array of random variables")
 
 """
 Add a variable node to the model with the given ID. This function is unsafe (doesn't check if a variable with the given name already exists in the model). 

--- a/src/model_macro.jl
+++ b/src/model_macro.jl
@@ -261,8 +261,7 @@ what_walk(::typeof(add_get_or_create_expression)) =
 function generate_get_or_create(s::Symbol)
     # I really don't like this fix, but I don't see a better way to do it
     return quote
-        $s = @isdefined($s) ? $s : GraphPPL.getorcreate!(model, context, $(QuoteNode(s)))
-        @assert $s isa GraphPPL.NodeLabel
+        $s = @isdefined($s) ? GraphPPL.get_individual_variable($s) : GraphPPL.getorcreate!(model, context, $(QuoteNode(s)))
     end
 end
 

--- a/src/model_macro.jl
+++ b/src/model_macro.jl
@@ -259,9 +259,10 @@ what_walk(::typeof(add_get_or_create_expression)) =
     guarded_walk((x) -> (x isa Expr && x.args[1] == :created_by))
 
 function generate_get_or_create(s::Symbol)
-    # I really don't like this fix, but I don't see a better way to do it
     return quote
-        $s = @isdefined($s) ? GraphPPL.get_individual_variable($s) : GraphPPL.getorcreate!(model, context, $(QuoteNode(s)))
+        $s =
+            @isdefined($s) ? GraphPPL.get_individual_variable($s) :
+            GraphPPL.getorcreate!(model, context, $(QuoteNode(s)))
     end
 end
 

--- a/test/graph_engine.jl
+++ b/test/graph_engine.jl
@@ -421,6 +421,25 @@ using TestSetExtensions
         @test z == x
 
     end
+    
+    @testset "get_individual_variable" begin
+        import GraphPPL: create_model, get_individual_variable, getorcreatearray!, getorcreate!
+
+        # Test case 1: check that get_individual_variable returns the variable created by getorcreate
+        model = create_model()
+        ctx = context(model)
+        x = getorcreate!(model, ctx, :x)
+        @test get_individual_variable(x) == x
+
+        # Test case 2: check that get_individual_variable returns an ErrorException when called with a vector of random variables
+
+        model = create_model()
+        ctx = context(model)
+        x = getorcreatearray!(model, ctx, :x, Val(1))
+        getorcreate!(model, ctx, :x, 1)
+        @test_throws ErrorException get_individual_variable(x)
+        
+    end
 
     @testset "add_variable_node!" begin
         import GraphPPL:

--- a/test/graph_engine.jl
+++ b/test/graph_engine.jl
@@ -421,9 +421,10 @@ using TestSetExtensions
         @test z == x
 
     end
-    
+
     @testset "get_individual_variable" begin
-        import GraphPPL: create_model, get_individual_variable, getorcreatearray!, getorcreate!
+        import GraphPPL:
+            create_model, get_individual_variable, getorcreatearray!, getorcreate!
 
         # Test case 1: check that get_individual_variable returns the variable created by getorcreate
         model = create_model()
@@ -438,7 +439,7 @@ using TestSetExtensions
         x = getorcreatearray!(model, ctx, :x, Val(1))
         getorcreate!(model, ctx, :x, 1)
         @test_throws ErrorException get_individual_variable(x)
-        
+
     end
 
     @testset "add_variable_node!" begin

--- a/test/model_macro.jl
+++ b/test/model_macro.jl
@@ -1071,8 +1071,7 @@ using MacroTools
             x ~ Normal(0, 1) where {created_by=(x~Normal(0, 1))}
         end
         output = quote
-            x = @isdefined(x) ? x : GraphPPL.getorcreate!(model, context, :x)
-            @assert x isa GraphPPL.NodeLabel
+            x = @isdefined(x) ? GraphPPL.get_individual_variable(x) : GraphPPL.getorcreate!(model, context, :x)
             x ~ Normal(0, 1) where {created_by=(x~Normal(0, 1))}
         end
         @test_expression_generating apply_pipeline(input, add_get_or_create_expression) output
@@ -1132,14 +1131,12 @@ using MacroTools
             ) where {created_by=(x~Normal(Normal(0, 1), 1))}
         end
         output = quote
-            x = @isdefined(x) ? x : GraphPPL.getorcreate!(model, context, :x)
-            @assert x isa GraphPPL.NodeLabel
+            x = @isdefined(x) ? GraphPPL.get_individual_variable(x) : GraphPPL.getorcreate!(model, context, :x)
             x ~ Normal(
                 begin
                     $sym =
-                        @isdefined($sym) ? $sym :
+                        @isdefined($sym) ? GraphPPL.get_individual_variable($sym) :
                         GraphPPL.getorcreate!(model, context, $(QuoteNode(sym)))
-                    @assert $sym isa GraphPPL.NodeLabel
                     $sym ~ Normal(
                         0,
                         1,
@@ -1165,7 +1162,7 @@ using MacroTools
             x ~ Normal(0, 1) where {created_by=(x~Normal(0, 1) where {q=q(x)q(y)}),q=q(x)q(y)}
         end
         output = quote
-            x = @isdefined(x) ? x : GraphPPL.getorcreate!(model, context, :x)
+            x = @isdefined(x) ? GraphPPL.get_individual_variable(x) : GraphPPL.getorcreate!(model, context, :x)
             x ~ Normal(
                 0,
                 1,
@@ -1180,8 +1177,7 @@ using MacroTools
         # Test 1: test scalar variable
         output = generate_get_or_create(:x)
         desired_result = quote
-            x = @isdefined(x) ? x : GraphPPL.getorcreate!(model, context, :x)
-            @assert x isa GraphPPL.NodeLabel
+            x = @isdefined(x) ? GraphPPL.get_individual_variable(x) : GraphPPL.getorcreate!(model, context, :x)
         end
         @test_expression_generating output desired_result
 
@@ -1863,31 +1859,23 @@ using MacroTools
     end
 
     @testset "model_macro_interior" begin
-        import GraphPPL: model_macro_interior
+        import GraphPPL: model_macro_interior, create_model, context, getorcreate!, make_node!
 
         # Test 1: Test regular node creation input
         input = quote
             function test_model(μ, σ)
-                y[i] := μ
+                y[1] := μ
                 x ~ sum(μ, σ)
             end
         end
-        output = quote
-            function test_model end
-            GraphPPL.interfaces(::typeof(test_model)) = (:μ, :σ)
-            GraphPPL.NodeType(::typeof(test_model)) = GraphPPL.Composite()
-            function test_model(μ, σ)
-                model = GraphPPL.create_model()
-                context = GraphPPL.create_context()
-                arguments = []
-                for argument in (:μ, :σ)
-                    argument = GraphPPL.getorcreate!(model, context, argument)
-                    push!(arguments, argument)
-                end
-                args = (; zip((:μ, :σ), arguments)...)
-                GraphPPL.make_node!(model, context, test_model, args)
-            end
-        end
+        eval(model_macro_interior(input))
+        model = create_model()
+        ctx = context(model)
+        μ = getorcreate!(model, ctx, :μ)
+        σ = getorcreate!(model, ctx, :σ)
+        make_node!(model, ctx, test_model, (μ = μ, σ = σ); options=nothing, debug=false)
+        @test nv(model) == 4 && ne(model) == 3
+        # @test ctx[:test_model_]
         # @test_expression_generating model_macro_interior(input) output
     end
 end

--- a/test/model_macro.jl
+++ b/test/model_macro.jl
@@ -1071,7 +1071,9 @@ using MacroTools
             x ~ Normal(0, 1) where {created_by=(x~Normal(0, 1))}
         end
         output = quote
-            x = @isdefined(x) ? GraphPPL.get_individual_variable(x) : GraphPPL.getorcreate!(model, context, :x)
+            x =
+                @isdefined(x) ? GraphPPL.get_individual_variable(x) :
+                GraphPPL.getorcreate!(model, context, :x)
             x ~ Normal(0, 1) where {created_by=(x~Normal(0, 1))}
         end
         @test_expression_generating apply_pipeline(input, add_get_or_create_expression) output
@@ -1131,7 +1133,9 @@ using MacroTools
             ) where {created_by=(x~Normal(Normal(0, 1), 1))}
         end
         output = quote
-            x = @isdefined(x) ? GraphPPL.get_individual_variable(x) : GraphPPL.getorcreate!(model, context, :x)
+            x =
+                @isdefined(x) ? GraphPPL.get_individual_variable(x) :
+                GraphPPL.getorcreate!(model, context, :x)
             x ~ Normal(
                 begin
                     $sym =
@@ -1162,7 +1166,9 @@ using MacroTools
             x ~ Normal(0, 1) where {created_by=(x~Normal(0, 1) where {q=q(x)q(y)}),q=q(x)q(y)}
         end
         output = quote
-            x = @isdefined(x) ? GraphPPL.get_individual_variable(x) : GraphPPL.getorcreate!(model, context, :x)
+            x =
+                @isdefined(x) ? GraphPPL.get_individual_variable(x) :
+                GraphPPL.getorcreate!(model, context, :x)
             x ~ Normal(
                 0,
                 1,
@@ -1177,7 +1183,9 @@ using MacroTools
         # Test 1: test scalar variable
         output = generate_get_or_create(:x)
         desired_result = quote
-            x = @isdefined(x) ? GraphPPL.get_individual_variable(x) : GraphPPL.getorcreate!(model, context, :x)
+            x =
+                @isdefined(x) ? GraphPPL.get_individual_variable(x) :
+                GraphPPL.getorcreate!(model, context, :x)
         end
         @test_expression_generating output desired_result
 
@@ -1859,7 +1867,8 @@ using MacroTools
     end
 
     @testset "model_macro_interior" begin
-        import GraphPPL: model_macro_interior, create_model, context, getorcreate!, make_node!
+        import GraphPPL:
+            model_macro_interior, create_model, context, getorcreate!, make_node!
 
         # Test 1: Test regular node creation input
         input = quote
@@ -1873,10 +1882,30 @@ using MacroTools
         ctx = context(model)
         μ = getorcreate!(model, ctx, :μ)
         σ = getorcreate!(model, ctx, :σ)
-        make_node!(model, ctx, test_model, (μ = μ, σ = σ); options=nothing, debug=false)
+        make_node!(model, ctx, test_model, (μ = μ, σ = σ); options = nothing, debug = false)
         @test nv(model) == 4 && ne(model) == 3
-        # @test ctx[:test_model_]
-        # @test_expression_generating model_macro_interior(input) output
+
+
+        # Test 2: Test illegal redefinition of node as individual variable
+        input = quote
+            function illegal_model(μ, σ)
+                x[1] := μ
+                x ~ sum(μ, σ)
+            end
+        end
+        eval(model_macro_interior(input))
+        model = create_model()
+        ctx = context(model)
+        μ = getorcreate!(model, ctx, :μ)
+        σ = getorcreate!(model, ctx, :σ)
+        @test_throws ErrorException make_node!(
+            model,
+            ctx,
+            illegal_model,
+            (μ = μ, σ = σ);
+            options = nothing,
+            debug = false,
+        )
     end
 end
 


### PR DESCRIPTION
And is consistently an `ErrorException`.