### PR TITLE
Adding a constraint checks if it can be applied in current scope

### DIFF
--- a/src/constraints_engine.jl
+++ b/src/constraints_engine.jl
@@ -318,7 +318,7 @@ const Constraint = Union{
     GeneralSubModelConstraints,
     SpecificSubModelConstraints,
 }
-struct Constraints 
+struct Constraints
     factorization_constraints::Vector{FactorizationConstraint}
     functional_form_constraints::Vector{FunctionalFormConstraint}
     message_constraints::Vector{MessageConstraint}
@@ -326,8 +326,14 @@ struct Constraints
 end
 
 Constraints() = Constraints([], [], [], [])
-Constraints(constraints :: Vector{<:Constraint}) = begin c=Constraints(); for constraint in constraints Base.push!(c, constraint) end; return c end
-function Base.push!(c::Constraints, constraint::FactorizationConstraint{V, F} where {V, F}) 
+Constraints(constraints::Vector{<:Constraint}) = begin
+    c = Constraints()
+    for constraint in constraints
+        Base.push!(c, constraint)
+    end
+    return c
+end
+function Base.push!(c::Constraints, constraint::FactorizationConstraint{V,F} where {V,F})
     if any(getvariables.(c.factorization_constraints) .== Ref(getvariables(constraint)))
         error("Cannot add $(constraint) to $(c). Variable names should be unique.")
     end

--- a/test/constraints_engine.jl
+++ b/test/constraints_engine.jl
@@ -435,6 +435,17 @@ include("model_zoo.jl")
         )
         push!(constraints, constraint)
         @test_throws ErrorException push!(constraints, constraint)
+        constraint = FactorizationConstraint(
+            [IndexedVariable(:x, 1), IndexedVariable(:y, 1)],
+            [
+                FactorizationConstraintEntry([
+                    IndexedVariable(:x, nothing),
+                    IndexedVariable(:y, nothing),
+                ]),
+            ],
+        )
+        push!(constraints, constraint)
+        @test_throws ErrorException push!(constraints, constraint)
 
         # Test 2: Test push! with FunctionalFormConstraint
         constraint = FunctionalFormConstraint(IndexedVariable(:x, nothing), Normal)
@@ -446,9 +457,21 @@ include("model_zoo.jl")
         )
         push!(constraints, constraint)
         @test_throws ErrorException push!(constraints, constraint)
+        constraint = FunctionalFormConstraint(IndexedVariable(:x, 1), Normal)
+        push!(constraints, constraint)
+        @test_throws ErrorException push!(constraints, constraint)
+        constraint = FunctionalFormConstraint(
+            [IndexedVariable(:x, 1), IndexedVariable(:y, 1)],
+            Normal,
+        )
+        push!(constraints, constraint)
+        @test_throws ErrorException push!(constraints, constraint)
 
         # Test 3: Test push! with MessageConstraint
         constraint = MessageConstraint(IndexedVariable(:x, nothing), Normal)
+        push!(constraints, constraint)
+        @test_throws ErrorException push!(constraints, constraint)
+        constraint = MessageConstraint(IndexedVariable(:x, 2), Normal)
         push!(constraints, constraint)
         @test_throws ErrorException push!(constraints, constraint)
 

--- a/test/constraints_engine.jl
+++ b/test/constraints_engine.jl
@@ -421,7 +421,7 @@ include("model_zoo.jl")
             SpecificSubModelConstraints,
             GeneralSubModelConstraints,
             IndexedVariable
-        
+
         # Test 1: Test push! with FactorizationConstraint
         constraints = Constraints()
         constraint = FactorizationConstraint(
@@ -440,7 +440,10 @@ include("model_zoo.jl")
         constraint = FunctionalFormConstraint(IndexedVariable(:x, nothing), Normal)
         push!(constraints, constraint)
         @test_throws ErrorException push!(constraints, constraint)
-        constraint = FunctionalFormConstraint([IndexedVariable(:x, nothing), IndexedVariable(:y, nothing)], Normal)
+        constraint = FunctionalFormConstraint(
+            [IndexedVariable(:x, nothing), IndexedVariable(:y, nothing)],
+            Normal,
+        )
         push!(constraints, constraint)
         @test_throws ErrorException push!(constraints, constraint)
 
@@ -452,7 +455,7 @@ include("model_zoo.jl")
         # Test 4: Test push! with SpecificSubModelConstraints
         constraint = SpecificSubModelConstraints(:first_submodel_3, Constraints())
         push!(constraints, constraint)
-        @test_throws ErrorException push!(constraints, constraint) 
+        @test_throws ErrorException push!(constraints, constraint)
 
         # Test 5: Test push! with GeneralSubModelConstraints
         constraint = GeneralSubModelConstraints(second_submodel, Constraints())
@@ -482,8 +485,8 @@ include("model_zoo.jl")
             ],
         )
         push!(constraints, constraint)
-        @test getconstraint(constraints) == Constraints(GraphPPL.Constraint[
-            FactorizationConstraint(
+        @test getconstraint(constraints) == Constraints(
+            GraphPPL.Constraint[FactorizationConstraint(
                 [IndexedVariable(:x, nothing), IndexedVariable(:y, nothing)],
                 [
                     FactorizationConstraintEntry([
@@ -491,24 +494,29 @@ include("model_zoo.jl")
                         IndexedVariable(:y, nothing),
                     ]),
                 ],
-            ),
-        ])
+            ),],
+        )
         @test_throws MethodError push!(constraints, "string")
 
         # Test 2: Test push! with FunctionalFormConstraint
         constraints = SubModelConstraints(second_submodel)
         constraint = FunctionalFormConstraint(IndexedVariable(:x, nothing), Normal)
         push!(constraints, constraint)
-        @test getconstraint(constraints) ==
-        Constraints(GraphPPL.Constraint[FunctionalFormConstraint(IndexedVariable(:x, nothing), Normal)])
+        @test getconstraint(constraints) == Constraints(
+            GraphPPL.Constraint[FunctionalFormConstraint(
+                IndexedVariable(:x, nothing),
+                Normal,
+            )],
+        )
         @test_throws MethodError push!(constraints, "string")
 
         # Test 3: Test push! with MessageConstraint
         constraints = SubModelConstraints(second_submodel)
         constraint = MessageConstraint(IndexedVariable(:x, nothing), Normal)
         push!(constraints, constraint)
-        @test getconstraint(constraints) ==
-        Constraints(GraphPPL.Constraint[MessageConstraint(IndexedVariable(:x, nothing), Normal)])
+        @test getconstraint(constraints) == Constraints(
+            GraphPPL.Constraint[MessageConstraint(IndexedVariable(:x, nothing), Normal)],
+        )
         @test_throws MethodError push!(constraints, "string")
 
         # Test 4: Test push! with SpecificSubModelConstraints
@@ -523,8 +531,8 @@ include("model_zoo.jl")
             ],
         )
         push!(constraints, constraint)
-        @test getconstraint(constraints) == Constraints(GraphPPL.Constraint[
-            FactorizationConstraint(
+        @test getconstraint(constraints) == Constraints(
+            GraphPPL.Constraint[FactorizationConstraint(
                 [IndexedVariable(:x, nothing), IndexedVariable(:y, nothing)],
                 [
                     FactorizationConstraintEntry([
@@ -532,24 +540,29 @@ include("model_zoo.jl")
                         IndexedVariable(:y, nothing),
                     ]),
                 ],
-            ),
-        ])
+            ),],
+        )
         @test_throws MethodError push!(constraints, "string")
 
         # Test 5: Test push! with FunctionalFormConstraint
         constraints = SubModelConstraints(:second_submodel)
         constraint = FunctionalFormConstraint(IndexedVariable(:x, nothing), Normal)
         push!(constraints, constraint)
-        @test getconstraint(constraints) ==
-        Constraints(GraphPPL.Constraint[FunctionalFormConstraint(IndexedVariable(:x, nothing), Normal)])
+        @test getconstraint(constraints) == Constraints(
+            GraphPPL.Constraint[FunctionalFormConstraint(
+                IndexedVariable(:x, nothing),
+                Normal,
+            )],
+        )
         @test_throws MethodError push!(constraints, "string")
 
         # Test 6: Test push! with MessageConstraint
         constraints = SubModelConstraints(:second_submodel)
         constraint = MessageConstraint(IndexedVariable(:x, nothing), Normal)
         push!(constraints, constraint)
-        @test getconstraint(constraints) ==
-        Constraints(GraphPPL.Constraint[MessageConstraint(IndexedVariable(:x, nothing), Normal)])
+        @test getconstraint(constraints) == Constraints(
+            GraphPPL.Constraint[MessageConstraint(IndexedVariable(:x, nothing), Normal)],
+        )
         @test_throws MethodError push!(constraints, "string")
 
     end
@@ -1574,16 +1587,18 @@ include("model_zoo.jl")
         # Test 1: Test that the full pipeline works with a MeanField constraint
         model = create_vector_model()
         ctx = GraphPPL.getcontext(model)
-        constraint = Constraints([
-            FactorizationConstraint(
-                (
-                    IndexedVariable(:x, nothing),
-                    IndexedVariable(:y, nothing),
-                    IndexedVariable(:out, nothing),
+        constraint = Constraints(
+            GraphPPL.Constraint[
+                FactorizationConstraint(
+                    (
+                        IndexedVariable(:x, nothing),
+                        IndexedVariable(:y, nothing),
+                        IndexedVariable(:out, nothing),
+                    ),
+                    MeanField(),
                 ),
-                MeanField(),
-            ),
-        ], [], [],[])
+            ]
+        )
         apply!(model, ctx, constraint)
         materialize_constraints!(model)
         @test node_options(model[ctx[:sum_4]])[:q] ==
@@ -1592,16 +1607,18 @@ include("model_zoo.jl")
         # Test 2: Test that the full pipeline works with a FullFactorization constraint
         model = create_vector_model()
         ctx = GraphPPL.getcontext(model)
-        constraint = Constraints([
-            FactorizationConstraint(
-                (
-                    IndexedVariable(:x, nothing),
-                    IndexedVariable(:y, nothing),
-                    IndexedVariable(:out, nothing),
+        constraint = Constraints(
+            GraphPPL.Constraint[
+                FactorizationConstraint(
+                    (
+                        IndexedVariable(:x, nothing),
+                        IndexedVariable(:y, nothing),
+                        IndexedVariable(:out, nothing),
+                    ),
+                    FullFactorization(),
                 ),
-                FullFactorization(),
-            ),
-        ], [], [],[])
+            ]
+        )
         apply!(model, ctx, constraint)
         materialize_constraints!(model)
         @test node_options(model[ctx[:sum_4]])[:q] ==
@@ -1619,28 +1636,32 @@ include("model_zoo.jl")
         # Test 4: Test model with fixed order of indices
         model = create_normal_model()
         ctx = GraphPPL.getcontext(model)
-        constraints = Constraints(GraphPPL.Constraint[
-            FunctionalFormConstraint(IndexedVariable(:x, nothing), Normal),
-            GeneralSubModelConstraints(
-                second_submodel,
-                Constraints([
-                    FactorizationConstraint(
-                        (
-                            IndexedVariable(:w, nothing),
-                            IndexedVariable(:a, nothing),
-                            IndexedVariable(:b, nothing),
-                        ),
-                        [
-                            FactorizationConstraintEntry([
+        constraints = Constraints(
+            GraphPPL.Constraint[
+                FunctionalFormConstraint(IndexedVariable(:x, nothing), Normal),
+                GeneralSubModelConstraints(
+                    second_submodel,
+                    Constraints([
+                        FactorizationConstraint(
+                            (
+                                IndexedVariable(:w, nothing),
                                 IndexedVariable(:a, nothing),
                                 IndexedVariable(:b, nothing),
-                            ]),
-                            FactorizationConstraintEntry([IndexedVariable(:w, nothing)]),
-                        ],
-                    ),
-                ]),
-            ),
-        ])
+                            ),
+                            [
+                                FactorizationConstraintEntry([
+                                    IndexedVariable(:a, nothing),
+                                    IndexedVariable(:b, nothing),
+                                ]),
+                                FactorizationConstraintEntry([
+                                    IndexedVariable(:w, nothing),
+                                ]),
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        )
         apply!(model, ctx, constraints)
         materialize_constraints!(model)
         node = label_for(model.graph, 5)


### PR DESCRIPTION
Makes stuff like 
```julia
q(x, y, z) = q(x, y)q(z)
q(x, y, z) = q(x)q(y, z)
q(x)::Normal
q(x)::Pointmass
```
illegal