### PR TITLE
Constraints performance

### DIFF
--- a/src/constraints_engine.jl
+++ b/src/constraints_engine.jl
@@ -902,16 +902,18 @@ function is_decoupled(
 end
 
 function is_decoupled_one_linked(linked::VariableNodeData, unlinked::VariableNodeData, constraint::ResolvedFactorizationConstraint)
+    # Check only links that are actually relevant to the factorization constraint,
+    # We skip links that are already factorized explicitly since there is no need to check them again
+    links = Iterators.filter(link -> !is_factorized(link), getlink(linked)) 
     # Check if all linked variables have exactly the same "is_decoupled" output
     # Otherwise we are being a bit conservative here and throw an ambiguity error
-    links = getlink(linked)
     if allequal(Iterators.map(link -> is_decoupled(link, unlinked, constraint), links))
         return is_decoupled(first(links), unlinked, constraint)
     else
         # Perhaps, this is possible to resolve automatically, but that would required 
         # quite some difficult graph traversal logic, so for now we just throw an error
-        error("""
-            Cannot resolve factorization constraint $(constraint) for an anonymous variable connected to variables $(join(getlink(var_1), ',')).
+        error(lazy"""
+            Cannot resolve factorization constraint $(constraint) for an anonymous variable connected to variables $(join(getlink(linked), ',')).
             As a workaround specify the name and the factorization constraint for the anonymous variable explicitly.
         """)
     end

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -213,7 +213,7 @@ struct StaticInterfaces{I} end
 
 StaticInterfaces(I::Tuple) = StaticInterfaces{I}()
     
-
+Base.getindex(::StaticInterfaces{I}, index) where {I} = I[index]
 
 struct ProxyLabel{T}
     name::Symbol

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -81,12 +81,12 @@ mutable struct VariableNodeOptions
 end
 
 VariableNodeOptions(;
-    value = nothing,
-    functional_form = nothing,
-    constant = false,
-    datavar = false,
-    factorized = false,
-    meta = nothing,
+    value=nothing,
+    functional_form=nothing,
+    constant=false,
+    datavar=false,
+    factorized=false,
+    meta=nothing,
 ) = VariableNodeOptions(value, functional_form, constant, datavar, factorized, meta)
 
 Base.:(==)(left::VariableNodeOptions, right::VariableNodeOptions) =
@@ -212,7 +212,7 @@ A structure that holds interfaces of a node in the type argument `I`. Used for d
 struct StaticInterfaces{I} end
 
 StaticInterfaces(I::Tuple) = StaticInterfaces{I}()
-    
+
 Base.getindex(::StaticInterfaces{I}, index) where {I} = I[index]
 
 struct ProxyLabel{T}
@@ -277,7 +277,7 @@ Base.getindex(model::Model, key::NodeLabel) = Base.getindex(model.graph, key)
 Base.getindex(model::Model, src::NodeLabel, dst::NodeLabel) =
     Base.getindex(model.graph, src, dst)
 Base.getindex(model::Model, keys::AbstractArray{NodeLabel}) = [model[key] for key in keys]
-
+Base.getindex(model::Model, keys::Base.Generator) = [model[key] for key in keys]
 
 function Base.getproperty(val::Model, p::Symbol)
     if p === :counter
@@ -299,7 +299,7 @@ increase_count(model::Model) = Base.setproperty!(model, :counter, model.counter 
 
 Graphs.nv(model::Model) = Graphs.nv(model.graph)
 Graphs.ne(model::Model) = Graphs.ne(model.graph)
-Graphs.edges(model::Model) = collect(Graphs.edges(model.graph))
+Graphs.edges(model::Model) = Graphs.edges(model.graph)
 MetaGraphsNext.label_for(model::Model, node_id::Int) =
     MetaGraphsNext.label_for(model.graph, node_id)
 
@@ -326,11 +326,8 @@ function __sortperm(model::Model, node::NodeLabel, edges::AbstractArray)
     return perm
 end
 
-__get_neighbors(model::Model, node::NodeLabel) =
-    label_for.(
-        (model.graph,),
-        collect(MetaGraphsNext.neighbors(model.graph, code_for(model.graph, node))),
-    )
+__get_neighbors(model::Model, node::NodeLabel) = Iterators.map(neighbor -> label_for(model, neighbor), MetaGraphsNext.neighbors(model.graph, code_for(model.graph, node)))
+
 __neighbors(model::Model, node::NodeLabel; sorted=false) =
     __neighbors(model, node, model[node]; sorted=sorted)
 __neighbors(model::Model, node::NodeLabel, node_data::VariableNodeData; sorted=false) =
@@ -339,7 +336,7 @@ __neighbors(model::Model, node::NodeLabel, node_data::FactorNodeData; sorted=fal
     __neighbors(model, node, static(sorted))
 __neighbors(model::Model, node::NodeLabel, ::False) = __get_neighbors(model, node)
 function __neighbors(model::Model, node::NodeLabel, ::True)
-    neighbors = __get_neighbors(model, node)
+    neighbors = collect(__get_neighbors(model, node))
     edges = __get_edges(model, node, neighbors)
     perm = __sortperm(model, node, edges)
     return neighbors[perm]
@@ -347,7 +344,7 @@ end
 Graphs.neighbors(model::Model, node::NodeLabel; sorted=false) =
     __neighbors(model, node; sorted=sorted)
 Graphs.neighbors(model::Model, nodes::AbstractArray; sorted=false) =
-    union(Graphs.neighbors.(Ref(model), nodes; sorted=sorted)...)
+    reduce(union, Graphs.neighbors.(Ref(model), nodes; sorted=sorted))
 Graphs.vertices(model::Model) = MetaGraphsNext.vertices(model.graph)
 MetaGraphsNext.labels(model::Model) = MetaGraphsNext.labels(model.graph)
 
@@ -790,7 +787,7 @@ function getorcreate!(
     ctx::Context,
     name::Symbol,
     index::Nothing;
-    options = VariableNodeOptions(),
+    options=VariableNodeOptions(),
 )
     check_if_vector_variable(ctx, name)
     check_if_tensor_variable(ctx, name)
@@ -806,15 +803,15 @@ getorcreate!(
     ctx::Context,
     name::Symbol,
     index::AbstractArray{Int};
-    options = VariableNodeOptions(),
-) = getorcreate!(model, ctx, name, index...; options = options)
+    options=VariableNodeOptions(),
+) = getorcreate!(model, ctx, name, index...; options=options)
 
 function getorcreate!(
     model::Model,
     ctx::Context,
     name::Symbol,
     index::Integer;
-    options = VariableNodeOptions(),
+    options=VariableNodeOptions(),
 )
     check_if_individual_variable(ctx, name)
     check_if_tensor_variable(ctx, name)
@@ -833,7 +830,7 @@ function getorcreate!(
     ctx::Context,
     name::Symbol,
     index...;
-    options = VariableNodeOptions(),
+    options=VariableNodeOptions(),
 )
     check_if_individual_variable(ctx, name)
     check_if_vector_variable(ctx, name)
@@ -856,7 +853,7 @@ getifcreated(model::Model, context::Context, var) = add_variable_node!(
     model,
     context,
     gensym(model, :constvar);
-    __options__ = VariableNodeOptions(value = var, constant = true),
+    __options__=VariableNodeOptions(value=var, constant=true),
 )
 
 
@@ -882,9 +879,9 @@ function add_variable_node!(
     model::Model,
     context::Context,
     variable_id::Symbol;
-    index = nothing,
+    index=nothing,
     link=nothing,
-    __options__ = VariableNodeOptions(),
+    __options__=VariableNodeOptions(),
 )
     variable_symbol = generate_nodelabel(model, variable_id)
     context[variable_id, index] = variable_symbol
@@ -898,9 +895,9 @@ end
 Defines a lazy structure for anonymous variables.
 The actual anonymous variables materialize only in `make_node!` upon calling, because it needs arguments to the `make_node!` in order to create proper links.
 """
-struct AnonymousVariable 
-    model :: Model
-    context :: Context
+struct AnonymousVariable
+    model::Model
+    context::Context
 end
 
 create_anonymous_variable!(model::Model, context::Context) = AnonymousVariable(model, context)
@@ -912,7 +909,7 @@ end
 # Deterministic nodes can create links to variables in the model
 # This might be important for better factorization constraints resolution
 function materialize_anonymous_variable!(::Deterministic, model::Model, context::Context, args)
-    return add_variable_node!(model, context, :anonymous, link = getindex.(Ref(model), unroll.(filter(is_nodelabel, args))))
+    return add_variable_node!(model, context, :anonymous, link=getindex.(Ref(model), unroll.(filter(is_nodelabel, args))))
 end
 
 function materialize_anonymous_variable!(::Deterministic, model::Model, context::Context, args::NamedTuple)
@@ -941,7 +938,7 @@ function add_atomic_factor_node!(
     model::Model,
     context::Context,
     fform;
-    __options__ = FactorNodeOptions(),
+    __options__=FactorNodeOptions(),
 )
     factornode_id = generate_factor_nodelabel(context, fform)
     factornode_label = generate_nodelabel(model, fform)
@@ -1045,7 +1042,7 @@ function missing_interfaces(fform, val, known_interfaces::NamedTuple)
     return missing_interfaces(interfaces(fform, val), StaticInterfaces(keys(known_interfaces)))
 end
 
-function missing_interfaces(::StaticInterfaces{all_interfaces}, ::StaticInterfaces{present_interfaces}) where {all_interfaces, present_interfaces}
+function missing_interfaces(::StaticInterfaces{all_interfaces}, ::StaticInterfaces{present_interfaces}) where {all_interfaces,present_interfaces}
     return StaticInterfaces(filter(interface -> interface ∉ present_interfaces, all_interfaces))
 end
 
@@ -1113,8 +1110,8 @@ make_node!(
     fform,
     lhs_interface,
     rhs_interfaces;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = make_node!(
     NodeType(fform),
     model,
@@ -1134,8 +1131,8 @@ make_node!(
     fform,
     lhs_interface,
     rhs_interfaces;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = make_node!(
     True(),
     nodetype,
@@ -1156,8 +1153,8 @@ make_node!(
     fform,
     lhs_interface,
     rhs_interfaces::Nothing;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = make_node!(
     True(),
     Atomic(),
@@ -1179,8 +1176,8 @@ make_node!(
     fform,
     lhs_interface,
     rhs_interfaces;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = make_node!(
     Atomic(),
     NodeBehaviour(fform),
@@ -1202,8 +1199,8 @@ make_node!(
     fform,
     lhs_interface,
     rhs_interfaces;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = make_node!(
     contains_nodelabel(rhs_interfaces),
     atomic,
@@ -1227,8 +1224,8 @@ make_node!(
     fform,
     lhs_interface,
     rhs_interfaces::AbstractArray;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = fform(rhs_interfaces...)
 
 make_node!(
@@ -1240,8 +1237,8 @@ make_node!(
     fform,
     lhs_interface,
     rhs_interfaces::NamedTuple;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = fform(; rhs_interfaces...)
 
 make_node!(
@@ -1267,8 +1264,8 @@ make_node!(
     fform,
     lhs_interface,
     rhs_interfaces;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = make_node!(
     True(),
     Atomic(),
@@ -1292,8 +1289,8 @@ function make_node!(
     fform,
     lhs_interface::Broadcasted,
     rhs_interfaces;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 )
     lhs_node = ProxyLabel(
         getname(lhs_interface),
@@ -1324,8 +1321,8 @@ make_node!(
     fform,
     lhs_interface::Union{NodeLabel,ProxyLabel},
     rhs_interfaces::AbstractArray;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = make_node!(
     True(),
     node_type,
@@ -1348,8 +1345,8 @@ make_node!(
     fform,
     lhs_interface::Union{NodeLabel,ProxyLabel},
     rhs_interfaces::MixedArguments;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = error(
     "MixedArguments not supported for rhs_interfaces when node has to be materialized",
 )
@@ -1363,8 +1360,8 @@ make_node!(
     fform,
     lhs_interface::Union{NodeLabel,ProxyLabel},
     rhs_interfaces::AbstractArray;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) =
     length(rhs_interfaces) == 0 ?
     make_node!(
@@ -1392,8 +1389,8 @@ make_node!(
     fform,
     lhs_interface::Union{NodeLabel,ProxyLabel},
     rhs_interfaces::NamedTuple;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = make_node!(
     Composite(),
     model,
@@ -1450,8 +1447,8 @@ function materialize_factor_node!(
     context::Context,
     fform,
     interfaces::NamedTuple;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 )
     factor_node_id =
         add_atomic_factor_node!(model, context, fform; __options__=__parent_options__)
@@ -1471,8 +1468,8 @@ add_terminated_submodel!(
     __context__::Context,
     fform,
     __interfaces__::NamedTuple;
-    __parent_options__ = FactorNodeOptions(),
-    __debug__ = false,
+    __parent_options__=FactorNodeOptions(),
+    __debug__=false,
 ) = add_terminated_submodel!(
     __model__,
     __context__,

--- a/test/constraints_engine_tests.jl
+++ b/test/constraints_engine_tests.jl
@@ -913,160 +913,166 @@ end
 
     include("model_zoo.jl")
 
-    __model__ = create_terminated_model(outer)
-    __context__ = GraphPPL.getcontext(__model__)
-    __inner_context__ = __context__[inner, 1]
-    __inner_inner_context__ = __inner_context__[inner_inner, 1]
+    model = create_terminated_model(outer)
+    context = GraphPPL.getcontext(model)
+    inner_context = context[inner, 1]
+    inner_inner_context = inner_context[inner_inner, 1]
 
-    __normal_node__ = __inner_inner_context__[NormalMeanVariance, 1]
+    normal_node = inner_inner_context[NormalMeanVariance, 1]
+    neighbors = model[GraphPPL.neighbors(model, normal_node)]
+
     let constraint = ResolvedFactorizationConstraint(
-            ResolvedConstraintLHS((ResolvedIndexedVariable(:w, 2:3, __context__),)),
+            ResolvedConstraintLHS((ResolvedIndexedVariable(:w, 2:3, context),)),
             (
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:w, 2, __context__),
+                    ResolvedIndexedVariable(:w, 2, context),
                 )),
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:w, 3, __context__),
+                    ResolvedIndexedVariable(:w, 3, context),
                 )),
             ),
         )
-        @test GraphPPL.is_applicable(__model__, __normal_node__, constraint)
-        @test GraphPPL.convert_to_bitsets(__model__, __normal_node__, constraint) ==
+        @test GraphPPL.is_applicable(model, normal_node, constraint)
+        @test GraphPPL.convert_to_bitsets(model, normal_node, neighbors, constraint) ==
               BitSetTuple([[1, 3], [2, 3], [1, 2, 3]])
     end
 
     let constraint = ResolvedFactorizationConstraint(
-            ResolvedConstraintLHS((ResolvedIndexedVariable(:w, 4:5, __context__),)),
+            ResolvedConstraintLHS((ResolvedIndexedVariable(:w, 4:5, context),)),
             (
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:w, 4, __context__),
+                    ResolvedIndexedVariable(:w, 4, context),
                 )),
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:w, 5, __context__),
+                    ResolvedIndexedVariable(:w, 5, context),
                 )),
             ),
         )
-        @test !GraphPPL.is_applicable(__model__, __normal_node__, constraint)
+        @test !GraphPPL.is_applicable(model, normal_node, constraint)
     end
 
     let constraint = ResolvedFactorizationConstraint(
-            ResolvedConstraintLHS((ResolvedIndexedVariable(:w, 2:3, __context__),)),
+            ResolvedConstraintLHS((ResolvedIndexedVariable(:w, 2:3, context),)),
             (
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:w, SplittedRange(2, 3), __context__),
+                    ResolvedIndexedVariable(:w, SplittedRange(2, 3), context),
                 )),
             ),
         )
-        @test GraphPPL.is_applicable(__model__, __normal_node__, constraint)
-        @test GraphPPL.convert_to_bitsets(__model__, __normal_node__, constraint) ==
+        @test GraphPPL.is_applicable(model, normal_node, constraint)
+        @test GraphPPL.convert_to_bitsets(model, normal_node, neighbors, constraint) ==
               BitSetTuple([[1, 3], [2, 3], [1, 2, 3]])
     end
 
     let constraint = ResolvedFactorizationConstraint(
             ResolvedConstraintLHS((
-                ResolvedIndexedVariable(:w, 2:3, __context__),
-                ResolvedIndexedVariable(:y, nothing, __context__),
+                ResolvedIndexedVariable(:w, 2:3, context),
+                ResolvedIndexedVariable(:y, nothing, context),
             )),
             (
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:w, SplittedRange(2, 3), __context__),
+                    ResolvedIndexedVariable(:w, SplittedRange(2, 3), context),
                 )),
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:y, nothing, __context__),
+                    ResolvedIndexedVariable(:y, nothing, context),
                 )),
             ),
         )
-        @test GraphPPL.is_applicable(__model__, __normal_node__, constraint)
-        @test GraphPPL.convert_to_bitsets(__model__, __normal_node__, constraint) ==
+        @test GraphPPL.is_applicable(model, normal_node, constraint)
+        @test GraphPPL.convert_to_bitsets(model, normal_node, neighbors, constraint) ==
               BitSetTuple([[1], [2], [3]])
     end
 
     let constraint = ResolvedFactorizationConstraint(
             ResolvedConstraintLHS((
-                ResolvedIndexedVariable(:w, 2:3, __context__),
-                ResolvedIndexedVariable(:y, nothing, __context__),
+                ResolvedIndexedVariable(:w, 2:3, context),
+                ResolvedIndexedVariable(:y, nothing, context),
             )),
             (
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:w, 2, __context__),
+                    ResolvedIndexedVariable(:w, 2, context),
                 )),
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:w, 3, __context__),
-                    ResolvedIndexedVariable(:y, nothing, __context__),
+                    ResolvedIndexedVariable(:w, 3, context),
+                    ResolvedIndexedVariable(:y, nothing, context),
                 )),
             ),
         )
-        @test GraphPPL.is_applicable(__model__, __normal_node__, constraint)
-        @test GraphPPL.convert_to_bitsets(__model__, __normal_node__, constraint) ==
+        @test GraphPPL.is_applicable(model, normal_node, constraint)
+        @test GraphPPL.convert_to_bitsets(model, normal_node, neighbors, constraint) ==
               BitSetTuple([[1], [2, 3], [2, 3]])
-        apply!(__model__, __normal_node__, constraint)
-        @test GraphPPL.factorization_constraint(__model__[__normal_node__]) ==
+        apply!(model, normal_node, constraint)
+        @test GraphPPL.factorization_constraint(model[normal_node]) ==
               BitSetTuple([[1], [2, 3], [2, 3]])
     end
 
     let constraint = ResolvedFactorizationConstraint(
             ResolvedConstraintLHS((
-                ResolvedIndexedVariable(:w, 2:3, __context__),
-                ResolvedIndexedVariable(:y, nothing, __context__),
+                ResolvedIndexedVariable(:w, 2:3, context),
+                ResolvedIndexedVariable(:y, nothing, context),
             )),
             (
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:w, CombinedRange(2, 3), __context__),
+                    ResolvedIndexedVariable(:w, CombinedRange(2, 3), context),
                 )),
                 ResolvedFactorizationConstraintEntry((
-                    ResolvedIndexedVariable(:y, nothing, __context__),
+                    ResolvedIndexedVariable(:y, nothing, context),
                 )),
             ),
         )
-        @test GraphPPL.is_applicable(__model__, __normal_node__, constraint)
-        @test GraphPPL.convert_to_bitsets(__model__, __normal_node__, constraint) ==
+        @test GraphPPL.is_applicable(model, normal_node, constraint)
+        @test GraphPPL.convert_to_bitsets(model, normal_node, neighbors, constraint) ==
               BitSetTuple([[1, 2], [1, 2], [3]])
     end
 
-    __model__ = create_terminated_model(multidim_array)
-    __context__ = GraphPPL.getcontext(__model__)
-    __normal_node__ = __context__[NormalMeanVariance, 5]
+    model = create_terminated_model(multidim_array)
+    context = GraphPPL.getcontext(model)
+    normal_node = context[NormalMeanVariance, 5]
+    neighbors = model[GraphPPL.neighbors(model, normal_node)]
+
     let constraint = ResolvedFactorizationConstraint(
-            ResolvedConstraintLHS((ResolvedIndexedVariable(:x, nothing, __context__),),),
+            ResolvedConstraintLHS((ResolvedIndexedVariable(:x, nothing, context),),),
             (
                 ResolvedFactorizationConstraintEntry((
                     ResolvedIndexedVariable(
                         :x,
                         SplittedRange(CartesianIndex(1, 1), CartesianIndex(3, 3)),
-                        __context__,
+                        context,
                     ),
                 )),
             ),
         )
-        @test GraphPPL.is_applicable(__model__, __normal_node__, constraint)
-        @test GraphPPL.convert_to_bitsets(__model__, __normal_node__, constraint) ==
+        @test GraphPPL.is_applicable(model, normal_node, constraint)
+        @test GraphPPL.convert_to_bitsets(model, normal_node, neighbors, constraint) ==
               BitSetTuple([[1, 3], [2, 3], [1, 2, 3]])
-        apply!(__model__, __normal_node__, constraint)
-        @test GraphPPL.factorization_constraint(__model__[__normal_node__]) ==
+        apply!(model, normal_node, constraint)
+        @test GraphPPL.factorization_constraint(model[normal_node]) ==
               BitSetTuple([[1, 3], [2, 3], [1, 2, 3]])
 
     end
 
-    __model__ = create_terminated_model(multidim_array)
-    __context__ = GraphPPL.getcontext(__model__)
-    __normal_node__ = __context__[NormalMeanVariance, 5]
+    model = create_terminated_model(multidim_array)
+    context = GraphPPL.getcontext(model)
+    normal_node = context[NormalMeanVariance, 5]
+    neighbors = model[GraphPPL.neighbors(model, normal_node)]
+
     let constraint = ResolvedFactorizationConstraint(
-            ResolvedConstraintLHS((ResolvedIndexedVariable(:x, nothing, __context__),),),
+            ResolvedConstraintLHS((ResolvedIndexedVariable(:x, nothing, context),),),
             (
                 ResolvedFactorizationConstraintEntry((
                     ResolvedIndexedVariable(
                         :x,
                         CombinedRange(CartesianIndex(1, 1), CartesianIndex(3, 3)),
-                        __context__,
+                        context,
                     ),
                 )),
             ),
         )
-        @test GraphPPL.is_applicable(__model__, __normal_node__, constraint)
-        @test GraphPPL.convert_to_bitsets(__model__, __normal_node__, constraint) ==
+        @test GraphPPL.is_applicable(model, normal_node, constraint)
+        @test GraphPPL.convert_to_bitsets(model, normal_node, neighbors, constraint) ==
               BitSetTuple([[1, 2, 3], [1, 2, 3], [1, 2, 3]])
-        apply!(__model__, __normal_node__, constraint)
-        @test GraphPPL.factorization_constraint(__model__[__normal_node__]) ==
+        apply!(model, normal_node, constraint)
+        @test GraphPPL.factorization_constraint(model[normal_node]) ==
               BitSetTuple([[1, 2, 3], [1, 2, 3], [1, 2, 3]])
 
     end

--- a/test/constraints_engine_tests.jl
+++ b/test/constraints_engine_tests.jl
@@ -1071,3 +1071,36 @@ end
 
     end
 end
+
+@testitem "lazy_bool_allequal" begin
+    import GraphPPL: lazy_bool_allequal
+
+    @testset begin 
+        itr = [ 1, 2, 3, 4 ]
+
+        outcome, value = lazy_bool_allequal(x -> x > 0, itr)
+        @test outcome === true
+        @test value === true
+
+        outcome, value = lazy_bool_allequal(x -> x < 0, itr)
+        @test outcome === true
+        @test value === false
+    end
+
+    @testset begin 
+        itr = [ 1, 2, -1, -2 ]
+
+        outcome, value = lazy_bool_allequal(x -> x > 0, itr)
+        @test outcome === false
+        @test value === true
+
+        outcome, value = lazy_bool_allequal(x -> x < 0, itr)
+        @test outcome === false
+        @test value === false
+    end
+
+    @testset begin 
+        # We do not support it for now, but we can add it in the future
+        @test_throws ErrorException lazy_bool_allequal(x -> x > 0, [])
+    end
+end

--- a/test/graph_engine_tests.jl
+++ b/test/graph_engine_tests.jl
@@ -420,7 +420,7 @@ end
     model[NodeLabel(:b, 2)] =
         VariableNodeData(:b, VariableNodeOptions(), nothing, nothing, __context__)
     model[NodeLabel(:a, 1), NodeLabel(:b, 2)] = EdgeLabel(:edge, 1)
-    @test neighbors(model, NodeLabel(:a, 1)) == [NodeLabel(:b, 2)]
+    @test collect(neighbors(model, NodeLabel(:a, 1))) == [NodeLabel(:b, 2)]
 
     model = create_model()
     __context__ = getcontext(model)
@@ -445,7 +445,7 @@ end
     model = create_terminated_model(vector_model)
     ctx = getcontext(model)
     node = first(neighbors(model, ctx[:z][1]))
-    @test getname.(neighbors(model, node; sorted = true)) == [:z, :x, :y]
+    @test getname.(collect(neighbors(model, node; sorted = true))) == [:z, :x, :y]
 
 end
 

--- a/test/graph_engine_tests.jl
+++ b/test/graph_engine_tests.jl
@@ -1618,3 +1618,14 @@ end
     @test size(z) == (2, 2)
 
 end
+
+@testitem "getindex for StaticInterfaces" begin 
+    import GraphPPL: StaticInterfaces
+
+    interfaces = (:a, :b, :c)
+    sinterfaces = StaticInterfaces(interfaces)
+
+    for (i, interface) in enumerate(interfaces)
+        @test sinterfaces[i] === interface
+    end
+end

--- a/test/integration_tests.jl
+++ b/test/integration_tests.jl
@@ -120,6 +120,63 @@ end
     end
 end
 
+@testitem "simple @model + structured @constraints + anonymous variable linked through a deterministic relation" begin
+    using Distributions, LinearAlgebra
+    using GraphPPL: create_model, getcontext, getorcreate!, add_terminated_submodel!, apply!, as_node, factorization_constraint, VariableNodeOptions
+
+    include("./model_zoo.jl")
+
+    @model function simple_model(y, a, b)
+
+        τ ~ Gamma(10, 10) # wrong for MvNormal, but test is for a different purpose
+        θ ~ Gamma(10, 10)
+
+        x[1] ~ Normal(0, 1)
+        y[1] ~ Normal(x[1], θ)
+    
+        for i in 2:length(y)
+            x[i] ~ MvNormal(a * x[i - 1] + b, τ)
+            y[i] ~ Normal(x[i], θ)
+        end
+
+    end
+
+    # Here we don't even need to specify anything, because 
+    # everything should be factorized out by default
+
+    constraints = @constraints begin 
+        q(x, τ, θ) = q(x)q(τ)q(θ)
+    end
+
+    # `nothing` here will create a `datavar`
+    for a in (nothing,), b in (nothing, 1, 1.0), n in (5, 10)
+        model = create_model()
+        context = getcontext(model)
+
+        a = something(a, getorcreate!(model, context, :a, nothing, options=VariableNodeOptions(datavar=true, factorized=true)))
+        b = something(b, getorcreate!(model, context, :b, nothing, options=VariableNodeOptions(datavar=true, factorized=true)))
+        
+        y = nothing
+        for i in 1:n
+            y = getorcreate!(model, context, :y, i, options=VariableNodeOptions(datavar=true, factorized=true))
+        end
+
+        add_terminated_submodel!(model, context, simple_model, (a=a, b=b, y=y))
+        apply!(model, constraints)
+
+        @test length(collect(filter(as_node(MvNormal), model))) === n - 1
+
+        @test all(filter(as_node(MvNormal), model)) do node
+            interfaces = GraphPPL.interfaces(MvNormal, static(3))
+            # desired constraints 
+            desired = Set([ (interfaces[1], interfaces[2]), (interfaces[3], ) ])
+            # actual constraints 
+            actual = Set(map(cluster -> GraphPPL.getname.(cluster), factorization_constraint(model[node])))
+            return isequal(desired, actual)
+        end
+    end
+end
+
 @testitem "state space @model (nested) + @constraints + anonymous variable linked through a deterministic relation" begin
     using Distributions
     using GraphPPL: create_model, getcontext, getorcreate!, add_terminated_submodel!, apply!, as_node, factorization_constraint, VariableNodeOptions


### PR DESCRIPTION
This PR improves the performance of the constraints application. Perhaps a lot more can be done, but this is also OK for now. On my small experiment I went from 

```
1.037032 seconds (13.11 M allocations: 609.419 MiB, 15.86% gc time)
```

to 

```
0.522466 seconds (7.28 M allocations: 284.243 MiB, 22.69% gc time)
```